### PR TITLE
Fix local gitlab container by exporting port 80

### DIFF
--- a/gitfab_local.yml
+++ b/gitfab_local.yml
@@ -27,6 +27,9 @@ services:
       - gitlab_logs:/var/log/gitlab
       - gitlab_data:/var/opt/gitlab
       - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+      - 8080:80
+      - 22:22
     environment:
       GITLAB_OMNIBUS_CONFIG: |
          external_url 'http://gitlab'


### PR DESCRIPTION
The port 80 must be reachable from outside the docker network.
Therefore it needs to be exported.
See also https://gist.github.com/steve-todorov/4758707

Port 22 must also be accessible. - But this does not work for now.

Signed-off-by: Juergen Kosel <juergen.kosel@gmx.de>